### PR TITLE
Hide miniGraph if spot is extended

### DIFF
--- a/frontend/src/overview/spotlist/spot/Spot.scss
+++ b/frontend/src/overview/spotlist/spot/Spot.scss
@@ -67,6 +67,16 @@ summary::-webkit-details-marker {
   text-overflow: ellipsis;
 }
 
+details.spot[open] summary.spotname {
+  .forecastContainer {
+    display: none;
+  }
+
+  .measurements {
+    flex-direction: row;
+  }
+}
+
 .spotContainer {
   flex: 1;
   display: flex;


### PR DESCRIPTION
- This change looks better, when merged with the other change, that happened at the same time (remove timestamp), because otherwise there is too much information to change the flex-direction to 'row'.