### PR TITLE
Fix bug with multiple users in db

### DIFF
--- a/backend/src/main/java/com/aa/msw/auth/RequestUserInterceptor.java
+++ b/backend/src/main/java/com/aa/msw/auth/RequestUserInterceptor.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Profile("!test")
@@ -31,6 +32,7 @@ public class RequestUserInterceptor implements HandlerInterceptor {
         this.userDao = userDao;
     }
 
+    @Transactional
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/backend/src/main/java/com/aa/msw/database/repository/UserRepository.java
+++ b/backend/src/main/java/com/aa/msw/database/repository/UserRepository.java
@@ -31,6 +31,7 @@ public class UserRepository extends AbstractRepository<UserId, User, UserTableRe
     }
 
     @Override
+    @Transactional
     public User getUser(UserExtId externalId) throws NoSuchUserException {
         try {
             return dsl.selectFrom(TABLE)


### PR DESCRIPTION
- before this fix, it happened, that a user was created multiple times (on downsync or on register)
- the userExtId was the same but the internal userId was different. It did not yet come to any problems, as the same spots were referenced and only returned once to the frontend, so "by accident" everything worked so far.
- I hope this fixes the problem. But I am not 100% sure, as it was a bit flaky before...
- deleted multiple entries in db after this commit