### PR TITLE
Fix NPE in historical data nightly refresh

### DIFF
--- a/backend/src/main/java/com/aa/msw/source/swiss/hydrodaten/AbstractSwissHydroLineFetchService.java
+++ b/backend/src/main/java/com/aa/msw/source/swiss/hydrodaten/AbstractSwissHydroLineFetchService.java
@@ -79,6 +79,7 @@ public abstract class AbstractSwissHydroLineFetchService extends AbstractFetchSe
             if (timestamp.isAfter(lastTimeStamp)) {
                 timestamps.add(timestamp);
                 flows.add(inputFlows.get(index));
+                lastTimeStamp = timestamp;
             }
         }
 

--- a/backend/src/main/java/com/aa/msw/source/swiss/hydrodaten/AbstractSwissHydroLineFetchService.java
+++ b/backend/src/main/java/com/aa/msw/source/swiss/hydrodaten/AbstractSwissHydroLineFetchService.java
@@ -66,7 +66,10 @@ public abstract class AbstractSwissHydroLineFetchService extends AbstractFetchSe
     protected HydroLine getFirstHalfOfHydroLine(
             List<OffsetDateTime> inputTimestamps,
             List<Double> inputFlows,
-            String name) {
+            String name) throws IOException {
+        if (inputTimestamps == null || inputFlows == null) {
+            throw new IOException("inputTimestamps or inputFlows is null for series: " + name);
+        }
         ArrayList<OffsetDateTime> timestamps = new ArrayList<>();
         ArrayList<Double> flows = new ArrayList<>();
 
@@ -83,7 +86,7 @@ public abstract class AbstractSwissHydroLineFetchService extends AbstractFetchSe
     }
 
 
-    protected TwentyFiveToSeventyFivePercentile getTwentyFiveToSeventyFivePercentile(HydroResponse hydroResponse) {
+    protected TwentyFiveToSeventyFivePercentile getTwentyFiveToSeventyFivePercentile(HydroResponse hydroResponse) throws IOException {
         // Hydrodaten does something very strange here. In this line, there are actually two lines.
         // The second line (25 percentile) is ordered backwards (timestamps descending)
         HydroLine twentyFiveToSeventyFivePercentile = hydroResponse.plot().data().get(2);


### PR DESCRIPTION
getFirstHalfOfHydroLine crashed with NullPointerException when a station's 25-75 percentile series returned a null x-field from the hydrodaten API. This caused the entire nightly batch to fail silently every midnight, leaving the historical chart frozen at April 27.

Throwing IOException instead of NPE lets the existing per-station catch in SwissHistoricalYearsDataFetchServiceImpl skip the bad station and persist data for all remaining stations normally.