### PR TITLE
Feature/admin refresh endpoints

### DIFF
--- a/backend/src/main/java/com/aa/msw/api/admin/AdminController.java
+++ b/backend/src/main/java/com/aa/msw/api/admin/AdminController.java
@@ -36,8 +36,8 @@ public class AdminController {
 
     @PostMapping("/refresh/historical")
     public ResponseEntity<String> refreshHistorical(
-            @RequestHeader(value = "Authorization", required = false) String authorization) {
-        if (!isAuthorized(authorization)) {
+            @RequestHeader(value = "X-Admin-Token", required = false) String token) {
+        if (!isAuthorized(token)) {
             return ResponseEntity.status(401).body("Unauthorized");
         }
         LOG.info("Admin: triggering historical data refresh");
@@ -47,8 +47,8 @@ public class AdminController {
 
     @PostMapping("/refresh/stations")
     public ResponseEntity<String> refreshStations(
-            @RequestHeader(value = "Authorization", required = false) String authorization) {
-        if (!isAuthorized(authorization)) {
+            @RequestHeader(value = "X-Admin-Token", required = false) String token) {
+        if (!isAuthorized(token)) {
             return ResponseEntity.status(401).body("Unauthorized");
         }
         LOG.info("Admin: triggering station refresh");
@@ -58,8 +58,8 @@ public class AdminController {
 
     @PostMapping("/refresh/samples")
     public ResponseEntity<String> refreshSamples(
-            @RequestHeader(value = "Authorization", required = false) String authorization) {
-        if (!isAuthorized(authorization)) {
+            @RequestHeader(value = "X-Admin-Token", required = false) String token) {
+        if (!isAuthorized(token)) {
             return ResponseEntity.status(401).body("Unauthorized");
         }
         LOG.info("Admin: triggering sample refresh");
@@ -67,11 +67,11 @@ public class AdminController {
         return ResponseEntity.ok("Sample refresh complete");
     }
 
-    private boolean isAuthorized(String authorization) {
+    private boolean isAuthorized(String token) {
         if (adminToken == null || adminToken.isBlank()) {
             LOG.warn("Admin endpoint called but ADMIN_TOKEN is not configured — rejecting");
             return false;
         }
-        return ("Bearer " + adminToken).equals(authorization);
+        return adminToken.equals(token);
     }
 }

--- a/backend/src/main/java/com/aa/msw/api/admin/AdminController.java
+++ b/backend/src/main/java/com/aa/msw/api/admin/AdminController.java
@@ -1,0 +1,77 @@
+package com.aa.msw.api.admin;
+
+import com.aa.msw.api.graph.historical.HistoricalYearsAccessorService;
+import com.aa.msw.api.station.StationApiService;
+import com.aa.msw.source.InputDataFetcherService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AdminController.class);
+
+    private final String adminToken;
+    private final HistoricalYearsAccessorService historicalYearsAccessorService;
+    private final StationApiService stationApiService;
+    private final InputDataFetcherService inputDataFetcherService;
+
+    public AdminController(
+            @Value("${admin.token:}") String adminToken,
+            HistoricalYearsAccessorService historicalYearsAccessorService,
+            StationApiService stationApiService,
+            InputDataFetcherService inputDataFetcherService) {
+        this.adminToken = adminToken;
+        this.historicalYearsAccessorService = historicalYearsAccessorService;
+        this.stationApiService = stationApiService;
+        this.inputDataFetcherService = inputDataFetcherService;
+    }
+
+    @PostMapping("/refresh/historical")
+    public ResponseEntity<String> refreshHistorical(
+            @RequestHeader(value = "Authorization", required = false) String authorization) {
+        if (!isAuthorized(authorization)) {
+            return ResponseEntity.status(401).body("Unauthorized");
+        }
+        LOG.info("Admin: triggering historical data refresh");
+        historicalYearsAccessorService.fetchHistoricalYearsDataAndSaveToDb();
+        return ResponseEntity.ok("Historical data refresh complete");
+    }
+
+    @PostMapping("/refresh/stations")
+    public ResponseEntity<String> refreshStations(
+            @RequestHeader(value = "Authorization", required = false) String authorization) {
+        if (!isAuthorized(authorization)) {
+            return ResponseEntity.status(401).body("Unauthorized");
+        }
+        LOG.info("Admin: triggering station refresh");
+        stationApiService.fetchStationsAndSaveToDb();
+        return ResponseEntity.ok("Station refresh complete");
+    }
+
+    @PostMapping("/refresh/samples")
+    public ResponseEntity<String> refreshSamples(
+            @RequestHeader(value = "Authorization", required = false) String authorization) {
+        if (!isAuthorized(authorization)) {
+            return ResponseEntity.status(401).body("Unauthorized");
+        }
+        LOG.info("Admin: triggering sample refresh");
+        inputDataFetcherService.triggerAllFetches();
+        return ResponseEntity.ok("Sample refresh complete");
+    }
+
+    private boolean isAuthorized(String authorization) {
+        if (adminToken == null || adminToken.isBlank()) {
+            LOG.warn("Admin endpoint called but ADMIN_TOKEN is not configured — rejecting");
+            return false;
+        }
+        return ("Bearer " + adminToken).equals(authorization);
+    }
+}

--- a/backend/src/main/java/com/aa/msw/auth/SecurityConfiguration.java
+++ b/backend/src/main/java/com/aa/msw/auth/SecurityConfiguration.java
@@ -29,6 +29,7 @@ public class SecurityConfiguration {
                 .requestMatchers(HttpMethod.GET, "/api/v1/historicalYears").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/forecast").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/spots").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/admin/**").permitAll()
                 .anyRequest().authenticated()
         ).httpBasic(withDefaults());
         return http.build();

--- a/backend/src/main/java/com/aa/msw/auth/SecurityConfiguration.java
+++ b/backend/src/main/java/com/aa/msw/auth/SecurityConfiguration.java
@@ -3,6 +3,7 @@ package com.aa.msw.auth;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -17,6 +18,16 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfiguration {
 
     @Bean
+    @Order(1)
+    public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
+        http.securityMatcher("/api/v1/admin/**")
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(requests -> requests.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
         http.oauth2ResourceServer(oAuth2ResourceServerConfigurer -> oAuth2ResourceServerConfigurer
@@ -29,7 +40,6 @@ public class SecurityConfiguration {
                 .requestMatchers(HttpMethod.GET, "/api/v1/historicalYears").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/forecast").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/spots").permitAll()
-                .requestMatchers(HttpMethod.POST, "/api/v1/admin/**").permitAll()
                 .anyRequest().authenticated()
         ).httpBasic(withDefaults());
         return http.build();

--- a/backend/src/main/java/com/aa/msw/source/InputDataFetcherService.java
+++ b/backend/src/main/java/com/aa/msw/source/InputDataFetcherService.java
@@ -143,6 +143,15 @@ public class InputDataFetcherService {
         return fetchedDataSinceRestart;
     }
 
+    public void triggerAllFetches() {
+        Set<ApiStationId> allIds = getAllStationIds();
+        fetchAndWriteSwissData(filterByCountry(allIds, CountryEnum.CH));
+        fetchAndWriteFrenchLatestSample(filterByCountry(allIds, CountryEnum.FR));
+        fetchAndWriteBwSamples(filterByCountry(allIds, CountryEnum.DE_BW));
+        updateCurrentInfoForAllSpotsOfStationsAndSendNotifications(allIds);
+        fetchedDataSinceRestart = true;
+    }
+
     private void fetchAndWriteFrenchLatestSample(Set<ApiStationId> stationIds) {
         // France does not have a call for the latest sample, so we fetch the last 30 days and use the newest as our current sample.
         List<Sample> currentSamples = frenchLast30DaysSampleFetchService.fetchLatestSamples(stationIds);

--- a/backend/src/main/java/com/aa/msw/source/swiss/hydrodaten/AbstractSwissHydroLineFetchService.java
+++ b/backend/src/main/java/com/aa/msw/source/swiss/hydrodaten/AbstractSwissHydroLineFetchService.java
@@ -66,7 +66,10 @@ public abstract class AbstractSwissHydroLineFetchService extends AbstractFetchSe
     protected HydroLine getFirstHalfOfHydroLine(
             List<OffsetDateTime> inputTimestamps,
             List<Double> inputFlows,
-            String name) {
+            String name) throws IOException {
+        if (inputTimestamps == null || inputFlows == null) {
+            throw new IOException("inputTimestamps or inputFlows is null for series: " + name);
+        }
         ArrayList<OffsetDateTime> timestamps = new ArrayList<>();
         ArrayList<Double> flows = new ArrayList<>();
 
@@ -83,7 +86,7 @@ public abstract class AbstractSwissHydroLineFetchService extends AbstractFetchSe
     }
 
 
-    protected TwentyFiveToSeventyFivePercentile getTwentyFiveToSeventyFivePercentile(HydroResponse hydroResponse) {
+    protected TwentyFiveToSeventyFivePercentile getTwentyFiveToSeventyFivePercentile(HydroResponse hydroResponse) throws IOException {
         // Hydrodaten does something very strange here. In this line, there are actually two lines.
         // The second line (25 percentile) is ordered backwards (timestamps descending)
         HydroLine twentyFiveToSeventyFivePercentile = hydroResponse.plot().data().get(2);


### PR DESCRIPTION
@AaronOderStudi Ich ha denkt das wär es nices feature zum de DB fetch manuell triggere. Schaffs allerdings nöd implementiere, Claude meint dezue
```
The WWW-Authenticate: Bearer with empty body is Spring Security's OAuth2 resource server rejecting the request — the permitAll() isn't helping because the Bearer token entry point fires before the authorization layer. We need a separate security filter chain for admin endpoints that has no OAuth2 resource server attached.
```
Mir wird's zkompliziert. Falls denksch das wär was, luegs der doch bitte mal ah und empfihl mer s wiitere vorgehe zum die sperri übergah :)