### PR TITLE
Fix forecast graph gap between measured data and forecast bands

### DIFF
--- a/frontend/src/overview/spotlist/spot/graph/forecast/MswForecastGraph.tsx
+++ b/frontend/src/overview/spotlist/spot/graph/forecast/MswForecastGraph.tsx
@@ -36,9 +36,20 @@ export const MswForecastGraph = (props: MswForecastGraphProps) => {
     const currentTime = currentSample?.timestamp;
 
     const useHistory = !props.isMini && (props.lastFewDays?.length ?? 0) > 0;
-    const pastMeasured: TimeSeriesPoint[] = useHistory
+    const baseMeasured: TimeSeriesPoint[] = useHistory
         ? props.lastFewDays!.filter(s => !currentTime || s.timestamp <= currentTime)
         : (measuredData ?? []);
+
+    // The forecast bands below are cut off at currentTime (the latest live
+    // sample), but the measuredData fallback above is a snapshot frozen at
+    // forecast generation time, which can lag well behind currentTime (mini
+    // graphs, logged-out users without lastFewDays). Append the live current
+    // sample so "Measured" always reaches the same cutoff as the forecast
+    // bands, instead of leaving a gap between the two.
+    const lastMeasuredTime = baseMeasured.length ? baseMeasured[baseMeasured.length - 1].timestamp : undefined;
+    const pastMeasured: TimeSeriesPoint[] = (currentSample && currentTime && (!lastMeasuredTime || currentTime > lastMeasuredTime))
+        ? [...baseMeasured, currentSample]
+        : baseMeasured;
 
     // Get timestamps for x-axis grid and labels
     const allTimestamps = getTimestamps([...pastMeasured, ...median ?? []]);

--- a/localdev/seed-samples.sql
+++ b/localdev/seed-samples.sql
@@ -1,7 +1,8 @@
--- Seed sample_table with synthetic FLOW data for the last 10 days, for every
--- station currently in station_table. Values are not real — just a sine wave
--- with jitter, scaled per-station — but enough to render the "last few days"
--- graph in the UI without waiting for live fetches to accumulate.
+-- Seed sample_table with synthetic FLOW and TEMPERATURE data for the last 40
+-- days, for every station currently in station_table. Values are not real —
+-- just a sine wave with jitter, scaled per-station — but enough to render the
+-- "last few days" graph and the spot cards' current temperature in the UI
+-- without waiting for live fetches to accumulate.
 --
 -- Run against the local dev DB:
 --   docker exec -i msw-postgres psql -U backend -d msw < localdev/seed-samples.sql
@@ -10,10 +11,11 @@
 -- measurement_type) to skip rows that already exist.
 
 
---     uncomment this to delete samples of last 10 days
+--     uncomment this to delete samples of last 40 days
 DELETE
 FROM sample_table
-WHERE timestamp >= now() - INTERVAL '40 days';
+WHERE timestamp >= now() - INTERVAL '40 days'
+  AND measurement_type IN ('FLOW', 'TEMPERATURE');
 
 INSERT INTO sample_table (id, stationid, country, timestamp, value, measurement_type)
 SELECT gen_random_uuid(),
@@ -35,9 +37,29 @@ FROM station_table s
                     ) AS ts
 ON CONFLICT (timestamp, stationid, measurement_type) DO NOTHING;
 
+INSERT INTO sample_table (id, stationid, country, timestamp, value, measurement_type)
+SELECT gen_random_uuid(),
+       s.stationid,
+       s.country,
+       ts,
+       (
+               15 + (abs(hashtext(s.stationid)) % 8)
+                   + 5 * sin(extract(epoch FROM ts) / 86400.0)
+                   + random()
+       )::real,
+       'TEMPERATURE'::measurement_type
+FROM station_table s
+         CROSS JOIN generate_series(
+        now() - INTERVAL '40 days',
+        now(),
+        INTERVAL '30 minutes'
+                    ) AS ts
+ON CONFLICT (timestamp, stationid, measurement_type) DO NOTHING;
+
 SELECT country,
-       count(*) AS samples_in_last_10_days
+       measurement_type,
+       count(*) AS samples_in_last_40_days
 FROM sample_table
 WHERE timestamp >= now() - INTERVAL '40 days'
-GROUP BY country
-ORDER BY country;
+GROUP BY country, measurement_type
+ORDER BY country, measurement_type;


### PR DESCRIPTION
## Summary
- Fixes a visible gap on the forecast graph between the last "Measured" point and the first forecast band point, seen on mini graphs and on logged-out expanded graphs.
- Root cause: forecast bands are cut off at `currentSample.timestamp` (latest live sample), but when `lastFewDays` isn't available, the "Measured" line fell back to `forecast.measuredData` — a snapshot frozen at forecast generation time, which regularly lags the live cutoff since forecasts refresh less often than samples arrive.
- Fix: append the live `currentSample` point to the "Measured" series whenever it extends past what the fallback data already covers, so it always reaches the same cutoff the forecast bands use — independent of login state or mini/expanded mode.
- Also fixes a bug in `localdev/seed-samples.sql` discovered while testing: its `DELETE` had no `measurement_type` filter, so it silently wiped seeded `TEMPERATURE` samples (backing spot cards' current-temperature display) without the `INSERT` replacing them. Scoped the `DELETE` and added a matching synthetic `TEMPERATURE` block.

## Test plan
- [x] `npx react-scripts build` compiles cleanly, no new type/lint issues introduced.
- [x] Verified locally with seeded synthetic sample history (both the dense `lastFewDays` path and the sparse fallback path) that the Measured line now reaches the forecast bands with no gap.
- [x] Verified spot cards show `currentTemperature` again after fixing the seed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)